### PR TITLE
Rename Bid secret_k parameter

### DIFF
--- a/bid.proto
+++ b/bid.proto
@@ -18,7 +18,7 @@ message Bid {
 
 // Used to Request the creation of a Bid
 message BidTransactionRequest {
-    BlsScalar secret_k = 1;
+    BlsScalar secret_t = 1;
     StealthAddress pk_r = 2;
     BlsScalar seed = 3;
     fixed64 latest_consensus_round = 4;

--- a/bid.proto
+++ b/bid.proto
@@ -18,7 +18,7 @@ message Bid {
 
 // Used to Request the creation of a Bid
 message BidTransactionRequest {
-    BlsScalar secret_t = 1;
+    BlsScalar K = 1;
     StealthAddress pk_r = 2;
     BlsScalar seed = 3;
     fixed64 latest_consensus_round = 4;

--- a/bid.proto
+++ b/bid.proto
@@ -23,7 +23,7 @@ message BidTransactionRequest {
     BlsScalar seed = 3;
     fixed64 latest_consensus_round = 4;
     fixed64 latest_consensus_step = 5;
-    rusk.NewTransactionRequest tx = 5;
+    //rusk.Transaction tx = 5;
 }
 
 message BidTransaction {

--- a/bid.proto
+++ b/bid.proto
@@ -18,7 +18,7 @@ message Bid {
 
 // Used to Request the creation of a Bid
 message BidTransactionRequest {
-    BlsScalar K = 1;
+    BlsScalar k = 1;
     StealthAddress pk_r = 2;
     BlsScalar seed = 3;
     fixed64 latest_consensus_round = 4;

--- a/blindbid.proto
+++ b/blindbid.proto
@@ -13,7 +13,7 @@ service BlindBid {
 }
 
 message GenerateScoreRequest {
-    BlsScalar secret_k = 1;
+    BlsScalar secret_t = 1;
     BlsScalar seed = 2;
     JubJubCompressed secret_key = 3; 
     uint32 round = 4;

--- a/blindbid.proto
+++ b/blindbid.proto
@@ -13,7 +13,7 @@ service BlindBid {
 }
 
 message GenerateScoreRequest {
-    BlsScalar K = 1;
+    BlsScalar k = 1;
     BlsScalar seed = 2;
     JubJubCompressed secret_key = 3; 
     uint32 round = 4;

--- a/blindbid.proto
+++ b/blindbid.proto
@@ -13,7 +13,7 @@ service BlindBid {
 }
 
 message GenerateScoreRequest {
-    BlsScalar secret_t = 1;
+    BlsScalar K = 1;
     BlsScalar seed = 2;
     JubJubCompressed secret_key = 3; 
     uint32 round = 4;

--- a/transaction.proto
+++ b/transaction.proto
@@ -3,11 +3,10 @@ package rusk;
 
 import "basic_fields.proto";
 
-message TransactionInput { BlsScalar nullifier = 1; }
 message Crossover {
     JubJubCompressed value_comm = 1;
     BlsScalar nonce = 2;
-    PoseidonCypher encypted_data = 3;
+    PoseidonCipher encypted_data = 3;
 }
 message Fee {
     uint64 gas_limit = 1;
@@ -20,12 +19,12 @@ message Note {
     JubJubCompressed pk_r = 2;
     JubJubCompressed commitment = 3;
     BlsScalar nonce = 4;
-    PoseidonCypher encypted_data = 5;
+    PoseidonCipher encypted_data = 5;
 }
 
 message TransactionPayload {
     BlsScalar anchor = 1;
-    repeated TransactionInput inputs = 2;
+    repeated BlsScalar nullifier = 2;
     Crossover crossover = 3;
     repeated Note = 4;
     Fee fee = 5;


### PR DESCRIPTION
It was quite confusing to name this parameter secret_k since
it is just randomness and its not related at all to any key
or point.

Therefore, as @vlopes11 suggested, we rename it to `secret_t`
which seems less confusing.

After @julesdesmit correctly stated that we should respect the specs. The best option is to simply call it `K`.
Closes #15 