### PR TITLE
Fix go_package option

### DIFF
--- a/basic_fields.proto
+++ b/basic_fields.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 package rusk;
-option go_package = "github.com/dusk-network/rusk-schema/";
+option go_package = "github.com/dusk-network/rusk-schema;rusk";
 
 message BlsScalar { bytes data = 1; }
 message JubJubScalar { bytes data = 1; }

--- a/bid.proto
+++ b/bid.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 package rusk;
-option go_package = "github.com/dusk-network/rusk-schema/";
+option go_package = "github.com/dusk-network/rusk-schema;rusk";
 
 import "basic_fields.proto";
 import "keys.proto";

--- a/blindbid.proto
+++ b/blindbid.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 package rusk;
-option go_package = "github.com/dusk-network/rusk-schema/";
+option go_package = "github.com/dusk-network/rusk-schema;rusk";
 
 import "basic_fields.proto";
 import "transaction.proto";

--- a/echo.proto
+++ b/echo.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 package rusk;
-option go_package = "github.com/dusk-network/rusk-schema/";
+option go_package = "github.com/dusk-network/rusk-schema;rusk";
 
 message EchoRequest {
    string message = 1;

--- a/keys.proto
+++ b/keys.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 package rusk;
-option go_package = "github.com/dusk-network/rusk-schema/";
+option go_package = "github.com/dusk-network/rusk-schema;rusk";
 
 import "basic_fields.proto";
 

--- a/rusk.proto
+++ b/rusk.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 package rusk;
-option go_package = "github.com/dusk-network/rusk-schema/";
+option go_package = "github.com/dusk-network/rusk-schema;rusk";
 
 import "echo.proto";
 import "bid.proto";

--- a/transaction.proto
+++ b/transaction.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 package rusk;
-option go_package = "github.com/dusk-network/rusk-schema/";
+option go_package = "github.com/dusk-network/rusk-schema;rusk";
 
 import "basic_fields.proto";
 


### PR DESCRIPTION
This declares both the path and the
package name, avoiding autogenerated files being
in "package _", and breaking imports.

Fixes #25
See also: https://stackoverflow.com/a/62540631