### PR TITLE
Add endpoints and messages for Staking service

### DIFF
--- a/basic_fields.proto
+++ b/basic_fields.proto
@@ -5,5 +5,6 @@ option go_package = "github.com/dusk-network/rusk-schema;rusk";
 message BlsScalar { bytes data = 1; }
 message JubJubScalar { bytes data = 1; }
 message JubJubCompressed { bytes data = 1; }
+message BN256Point { bytes data = 1; }
 message PoseidonCipher { bytes data = 1; }
 message Proof { bytes data = 1; }

--- a/stake.proto
+++ b/stake.proto
@@ -3,13 +3,59 @@ package rusk;
 option go_package = "github.com/dusk-network/rusk-schema;rusk";
 
 import "transaction.proto";
+import "basic_fields.proto";
+import "rusk.proto";
 
 message StakeTransactionRequest {
     fixed64 value = 1;
-    bytes public_key_bls = 2;
+    BN256Point public_key_bls = 2;
+}
+
+message FindStakeRequest {
+    BN256Point pk = 1;
+}
+
+message FindStakeResponse {
+    repeated Stake stakes = 1;
+}
+
+message ExtendStakeRequest {
+    bytes identifier = 1;
+    BN256Point pk = 2;
+    BN256Point sig = 3;
+}
+
+message WithdrawStakeRequest {
+    bytes identifier = 1;
+    BN256Point pk = 2;
+    BN256Point sig = 3;
+    Note note = 4;
+}
+
+message SlashRequest {
+    BN256Point pk = 1;
+    fixed64 round = 2;
+    uint32 step = 3;
+    BlsScalar message1 = 4;
+    BlsScalar message2 = 5;
+    BN256Point sig1 = 6;
+    BN256Point sig2 = 7;
+    Note note = 8;
 }
 
 service StakeService {
     // Generate a new Stake transaction.
     rpc NewStake(StakeTransactionRequest) returns (Transaction) {}
+
+    // Find all stakes related to a provisioner public key.
+    rpc FindStake(FindStakeRequest) returns (FindStakeResponse) {}
+
+    // Extend a stake.
+    rpc ExtendStake(ExtendStakeRequest) returns (Transaction) {}
+
+    // Withdraw a stake.
+    rpc WithdrawStake(WithdrawStakeRequest) returns (Transaction) {}
+
+    // Slash a misbehaving provisioner.
+    rpc Slash(SlashRequest) returns (Transaction) {}
 }


### PR DESCRIPTION
Note that most methods simply return a
Transaction, since most of the methods will
modify storage. In this case, most of the methods
will need to go through a contract execution,
warranting the Transaction return type.

Additionally, Golang should not be concerned
with any of the information contained in
these transactions, so there are no
specific transaction messages being
returned, only the generic one.

Fixes #30 