### PR TITLE
Add missing imports to rusk.proto

### DIFF
--- a/rusk.proto
+++ b/rusk.proto
@@ -7,6 +7,8 @@ import "bid.proto";
 import "blindbid.proto";
 import "transaction.proto";
 import "keys.proto";
+import "transfer.proto";
+import "stake.proto";
 
 message VerifyStateTransitionRequest {
     repeated Transaction txs = 1;
@@ -32,12 +34,6 @@ message ExecuteStateTransitionResponse {
 message Provisioner {
     bytes public_key_bls = 1;
     repeated Stake stakes = 2;
-}
-
-message Stake {
-    fixed64 amount = 1;
-    fixed64 start_height = 2;
-    fixed64 end_height = 3;
 }
 
 message GetProvisionersRequest {}

--- a/stake.proto
+++ b/stake.proto
@@ -4,7 +4,12 @@ option go_package = "github.com/dusk-network/rusk-schema;rusk";
 
 import "transaction.proto";
 import "basic_fields.proto";
-import "rusk.proto";
+
+message Stake {
+    fixed64 amount = 1;
+    fixed64 start_height = 2;
+    fixed64 end_height = 3;
+}
 
 message StakeTransactionRequest {
     fixed64 value = 1;


### PR DESCRIPTION
This also moves the Stake message
to the stake proto file, in order to avoid
recursive imports.

Fixes #32