### PR TITLE
Implement a Transaction service, for creating generic txs

### DIFF
--- a/bid.proto
+++ b/bid.proto
@@ -26,6 +26,8 @@ message BidTransactionRequest {
     BlsScalar seed = 5;
     fixed64 latest_consensus_round = 6;
     fixed64 latest_consensus_step = 7;
+    fixed64 gas_limit = 8;
+    fixed64 gas_price = 9;
 }
 
 message BidTransaction {
@@ -47,6 +49,4 @@ service BidService {
     rpc NewBid(BidTransactionRequest) returns (BidTransaction) {}
     // Look for your owned Bids and return a list of them and it's hash repr
     rpc FindBid(FindBidRequest) returns (BidList) {}
-    // Request a wirhdraw of a Bid. Not supported yet.
-    //rpc NewWithdrawBid(WithdrawBidTransactionRequest) returns (WithdrawBidTransaction) {}
 }

--- a/stake.proto
+++ b/stake.proto
@@ -14,6 +14,8 @@ message Stake {
 message StakeTransactionRequest {
     fixed64 value = 1;
     BN256Point public_key_bls = 2;
+    fixed64 gas_limit = 3;
+    fixed64 gas_price = 4;
 }
 
 message FindStakeRequest {
@@ -24,43 +26,10 @@ message FindStakeResponse {
     repeated Stake stakes = 1;
 }
 
-message ExtendStakeRequest {
-    bytes identifier = 1;
-    BN256Point pk = 2;
-    BN256Point sig = 3;
-}
-
-message WithdrawStakeRequest {
-    bytes identifier = 1;
-    BN256Point pk = 2;
-    BN256Point sig = 3;
-    Note note = 4;
-}
-
-message SlashRequest {
-    BN256Point pk = 1;
-    fixed64 round = 2;
-    uint32 step = 3;
-    BlsScalar message1 = 4;
-    BlsScalar message2 = 5;
-    BN256Point sig1 = 6;
-    BN256Point sig2 = 7;
-    Note note = 8;
-}
-
 service StakeService {
     // Generate a new Stake transaction.
     rpc NewStake(StakeTransactionRequest) returns (Transaction) {}
 
     // Find all stakes related to a provisioner public key.
     rpc FindStake(FindStakeRequest) returns (FindStakeResponse) {}
-
-    // Extend a stake.
-    rpc ExtendStake(ExtendStakeRequest) returns (Transaction) {}
-
-    // Withdraw a stake.
-    rpc WithdrawStake(WithdrawStakeRequest) returns (Transaction) {}
-
-    // Slash a misbehaving provisioner.
-    rpc Slash(SlashRequest) returns (Transaction) {}
 }

--- a/transaction.proto
+++ b/transaction.proto
@@ -45,3 +45,17 @@ message Transaction {
     uint32 type = 2;
     TransactionPayload tx_payload = 3;
 }
+
+message TransactionRequest {
+    bytes contract_address = 1;
+    uint32 op_code = 2;
+    bytes arguments = 3;
+    fixed64 gas_limit = 4;
+    fixed64 gas_price = 5;
+}
+
+service TransactionService {
+    // A generic method to create a transaction which requires
+    // no special fields (no crossover, outputs, or specific proofs).
+    rpc NewTransaction(TransactionRequest) returns (Transaction) {}
+}

--- a/transfer.proto
+++ b/transfer.proto
@@ -8,6 +8,8 @@ import "keys.proto";
 message TransferTransactionRequest {
     fixed64 value = 1;
     StealthAddress recipient = 2;
+    fixed64 gas_limit = 3;
+    fixed64 gas_price = 4;
 }
 
 service Transfer {


### PR DESCRIPTION
This also gets rid of methods which were
previously there in other services, but can be
replaced by the generic one.

Fixes #42