### PR TITLE
Change Crossover Nonce to be a JubJubScalar

### DIFF
--- a/transaction.proto
+++ b/transaction.proto
@@ -7,7 +7,7 @@ import "keys.proto";
 
 message Crossover {
     JubJubCompressed value_comm = 1;
-    BlsScalar nonce = 2;
+    JubJubScalar nonce = 2;
     PoseidonCipher encypted_data = 3;
 }
 message Fee {


### PR DESCRIPTION
This aligns it with the phoenix-core
version of the Crossover.

Fixes #45