### PR TITLE
Update Bid & BlindBid proto types

### DIFF
--- a/bid.proto
+++ b/bid.proto
@@ -12,8 +12,8 @@ message Bid {
     bytes nonce = 3; // BlsScalar
     StealthAddress stealth_address = 4;
     bytes commitment = 5; // JubJubCompressed
-    bytes elegibility = 6; // BlsScalar
-    bytes expiration = 7; // BlsScalar
+    fixed64 elegibility = 6; // u64
+    fixed64 expiration = 7; // u64
 }
 
 // Used to Request the creation of a Bid
@@ -22,7 +22,7 @@ message BidTransactionRequest {
     uint64 value = 2;
     bytes secret = 3; // JubJubCompressed
     StealthAddress stealth_address = 4;
-    bytes seed = 5; // BlsScalar
+    byte seed = 5; // u8
     fixed64 latest_consensus_round = 6;
     fixed64 latest_consensus_step = 7;
     fixed64 gas_limit = 8;

--- a/blindbid.proto
+++ b/blindbid.proto
@@ -4,10 +4,10 @@ option go_package = "github.com/dusk-network/rusk-schema;rusk";
 
 message GenerateScoreRequest {
     bytes k = 1; // BlsScalar
-    bytes seed = 2; // BlsScalar
+    byte seed = 2; // u8
     bytes secret = 3; // JubJubCompressed 
-    uint32 round = 4;
-    uint32 step = 5;
+    uint64 round = 4;
+    uint64 step = 5;
     uint64 index_stored_bid = 6;
 }
 
@@ -20,10 +20,10 @@ message GenerateScoreResponse {
 message VerifyScoreRequest {
     bytes proof = 1;
     bytes score = 2; // BlsScalar
-    bytes seed = 3; // BlsScalar
+    byte seed = 3; // u8
     bytes prover_id = 4; // BlsScalar
     fixed64 round = 5;
-    uint32 step = 6;
+    fixed64 step = 6;
     uint64 index_stored_bid = 7;
 }
 

--- a/rusk.proto
+++ b/rusk.proto
@@ -14,7 +14,7 @@ import "reward.proto";
 message VerifyStateTransitionRequest {
     repeated Transaction txs = 1;
     fixed64 height = 2;
-    bytes seed = 3;
+    byte seed = 3;
 }
 
 message VerifyStateTransitionResponse {
@@ -24,7 +24,7 @@ message VerifyStateTransitionResponse {
 message ExecuteStateTransitionRequest {
     repeated Transaction txs = 1;
     fixed64 height = 2;
-    bytes seed = 3;
+    byte seed = 3;
 }
 
 message ExecuteStateTransitionResponse {


### PR DESCRIPTION
Since the latest spec was released, some fields have
finally been defined.

In one side, `latest_consensus_round` & `latest_consensus_step` fields
have been set to `fixed64`.
Then we have `seed` which is a consensus attribute that is represented
as an `u8`.